### PR TITLE
fix atomicity in createCarWithMakeAsync by adding transactionScope

### DIFF
--- a/backend/Repositories/CarRepository.cs
+++ b/backend/Repositories/CarRepository.cs
@@ -3,6 +3,7 @@ using backend.Repositories.Interfaces;
 using Dapper;
 using Microsoft.Data.SqlClient;
 using System.Text;
+using System.Data; // 👈 Додано для IDbTransaction
 
 namespace backend.Repositories
 {
@@ -162,11 +163,12 @@ namespace backend.Repositories
         }
 
         // ==============================
-        // CREATE
+        // CREATE (UPDATED FOR TRANSACTION)
         // ==============================
-        public async Task<Car?> CreateCarAsync(Car car)
+        public async Task<Car?> CreateCarAsync(Car car, IDbTransaction? transaction = null)
         {
-            using var connection = _connectionFactory.CreateConnection();
+            // 1. Використовуємо існуюче з'єднання з транзакції або створюємо нове
+            var connection = transaction?.Connection ?? _connectionFactory.CreateConnection();
 
             const string sql = @"
                 INSERT INTO Cars
@@ -190,7 +192,19 @@ namespace backend.Repositories
                 (@MakeId, @Model, @Year, @Price, @Color, @Vin, @SupplierId, @Description, @ImageUrl, @Condition, @Mileage, @BodyType, @Status);
             ";
 
-            return await connection.QuerySingleOrDefaultAsync<Car>(sql, car);
+            try
+            {
+                // 2. Передаємо transaction у Dapper
+                return await connection.QuerySingleOrDefaultAsync<Car>(sql, car, transaction: transaction);
+            }
+            finally
+            {
+                // 3. Закриваємо з'єднання ТІЛЬКИ якщо транзакції не було (ми створили його самі)
+                if (transaction == null)
+                {
+                    connection.Dispose();
+                }
+            }
         }
 
         // ==============================

--- a/backend/Repositories/Interfaces/ICarRepository.cs
+++ b/backend/Repositories/Interfaces/ICarRepository.cs
@@ -1,4 +1,5 @@
 ﻿using backend.Models;
+using System.Data;
 
 namespace backend.Repositories.Interfaces
 {
@@ -8,7 +9,7 @@ namespace backend.Repositories.Interfaces
         Task<IEnumerable<Car>> GetAllCarsAsync();
         Task<Car?> GetCarByIdAsync(int id);
         Task<IEnumerable<CarWithStats>> GetCarsWithStatsAsync();
-        Task<Car?> CreateCarAsync(Car car);
+        Task<Car?> CreateCarAsync(Car car, IDbTransaction? transaction = null);
         Task<Car?> UpdateCarAsync(Car car);
         Task<bool> DeleteCarAsync(int id);
         Task<bool> ExistsByMakeIdAsync(int makeId);

--- a/backend/Repositories/Interfaces/IMakeRepository.cs
+++ b/backend/Repositories/Interfaces/IMakeRepository.cs
@@ -1,4 +1,5 @@
 ﻿using backend.Models;
+using System.Data;
 
 namespace backend.Repositories.Interfaces
 {
@@ -6,10 +7,10 @@ namespace backend.Repositories.Interfaces
     {
         Task<IEnumerable<Make>> GetAllMakesAsync();
         Task<Make?> GetMakeByIdAsync(int id);
-        Task<Make?> GetMakeByNameAsync(string name);
-        Task<Make?> CreateMakeAsync(Make make);
+        Task<Make?> GetMakeByNameAsync(string name, IDbTransaction? transaction = null);
+        Task<Make?> CreateMakeAsync(Make make, IDbTransaction? transaction = null);
         Task<Make?> UpdateMakeAsync(Make make);
-        Task<bool> DeleteMakeAsync(int id);
+        Task<bool> DeleteMakeAsync(int id, IDbTransaction? transaction = null);
         Task<bool> ExistsByIdAsync(int id);
     }
 }

--- a/backend/Repositories/MakeRepository.cs
+++ b/backend/Repositories/MakeRepository.cs
@@ -2,6 +2,7 @@
 using backend.Repositories.Interfaces;
 using Dapper;
 using Microsoft.Data.SqlClient;
+using System.Data;
 
 namespace backend.Repositories
 {
@@ -18,7 +19,7 @@ namespace backend.Repositories
         // ==============================
         public async Task<IEnumerable<Make>> GetAllMakesAsync()
         {
-                        using var connection = _connectionFactory.CreateConnection();
+            using var connection = _connectionFactory.CreateConnection();
 
             const string sql = @"
                 SELECT id, Name
@@ -34,7 +35,7 @@ namespace backend.Repositories
         // ==============================
         public async Task<Make?> GetMakeByIdAsync(int id)
         {
-                        using var connection = _connectionFactory.CreateConnection();
+            using var connection = _connectionFactory.CreateConnection();
 
             const string sql = @"
                 SELECT id, Name
@@ -46,11 +47,12 @@ namespace backend.Repositories
         }
 
         // ==============================
-        // GET BY NAME
+        // GET BY NAME (UPDATED FOR TRANSACTION)
         // ==============================
-        public async Task<Make?> GetMakeByNameAsync(string name)
+        public async Task<Make?> GetMakeByNameAsync(string name, IDbTransaction? transaction = null)
         {
-                        using var connection = _connectionFactory.CreateConnection();
+            // 1. Connection management
+            var connection = transaction?.Connection ?? _connectionFactory.CreateConnection();
 
             const string sql = @"
                 SELECT id, Name
@@ -58,7 +60,19 @@ namespace backend.Repositories
                 WHERE Name = @Name;
             ";
 
-            return await connection.QuerySingleOrDefaultAsync<Make>(sql, new { Name = name });
+            try
+            {
+                // 2. Pass transaction
+                return await connection.QuerySingleOrDefaultAsync<Make>(sql, new { Name = name }, transaction: transaction);
+            }
+            finally
+            {
+                // 3. Dispose if we created it
+                if (transaction == null)
+                {
+                    connection.Dispose();
+                }
+            }
         }
 
         // ==============================
@@ -66,7 +80,7 @@ namespace backend.Repositories
         // ==============================
         public async Task<bool> ExistsByIdAsync(int id)
         {
-                        using var connection = _connectionFactory.CreateConnection();
+            using var connection = _connectionFactory.CreateConnection();
 
             const string sql = @"SELECT 1 FROM Makes WHERE id = @Id";
 
@@ -75,11 +89,11 @@ namespace backend.Repositories
         }
 
         // ==============================
-        // CREATE
+        // CREATE (UPDATED FOR TRANSACTION)
         // ==============================
-        public async Task<Make?> CreateMakeAsync(Make make)
+        public async Task<Make?> CreateMakeAsync(Make make, IDbTransaction? transaction = null)
         {
-                        using var connection = _connectionFactory.CreateConnection();
+            var connection = transaction?.Connection ?? _connectionFactory.CreateConnection();
 
             const string sql = @"
                 INSERT INTO Makes (Name)
@@ -87,7 +101,17 @@ namespace backend.Repositories
                 VALUES (@Name);
             ";
 
-            return await connection.QuerySingleOrDefaultAsync<Make>(sql, make);
+            try
+            {
+                return await connection.QuerySingleOrDefaultAsync<Make>(sql, make, transaction: transaction);
+            }
+            finally
+            {
+                if (transaction == null)
+                {
+                    connection.Dispose();
+                }
+            }
         }
 
         // ==============================
@@ -95,7 +119,7 @@ namespace backend.Repositories
         // ==============================
         public async Task<Make?> UpdateMakeAsync(Make make)
         {
-                        using var connection = _connectionFactory.CreateConnection();
+            using var connection = _connectionFactory.CreateConnection();
 
             const string sql = @"
                 UPDATE Makes
@@ -108,16 +132,26 @@ namespace backend.Repositories
         }
 
         // ==============================
-        // DELETE
+        // DELETE (UPDATED FOR TRANSACTION)
         // ==============================
-        public async Task<bool> DeleteMakeAsync(int id)
+        public async Task<bool> DeleteMakeAsync(int id, IDbTransaction? transaction = null)
         {
-                        using var connection = _connectionFactory.CreateConnection();
+            var connection = transaction?.Connection ?? _connectionFactory.CreateConnection();
 
             const string sql = @"DELETE FROM Makes WHERE id = @Id";
 
-            var affected = await connection.ExecuteAsync(sql, new { Id = id });
-            return affected > 0;
+            try
+            {
+                var affected = await connection.ExecuteAsync(sql, new { Id = id }, transaction: transaction);
+                return affected > 0;
+            }
+            finally
+            {
+                if (transaction == null)
+                {
+                    connection.Dispose();
+                }
+            }
         }
     }
 }

--- a/backend/Services/CarService.cs
+++ b/backend/Services/CarService.cs
@@ -17,7 +17,7 @@ namespace backend.Services
         private readonly ISupplierRepository _supplierRepository;
         private readonly IDbConnectionFactory _connectionFactory;
 
-        public CarService(ICarRepository carRepository, ISaleRepository saleRepository,IOrderRepository orderRepository, IMakeRepository makeRepository, ISupplierRepository supplierRepository, IDbConnectionFactory connectionFactory)
+        public CarService(ICarRepository carRepository, ISaleRepository saleRepository, IOrderRepository orderRepository, IMakeRepository makeRepository, ISupplierRepository supplierRepository, IDbConnectionFactory connectionFactory)
         {
             _carRepository = carRepository;
             _saleRepository = saleRepository;
@@ -34,7 +34,6 @@ namespace backend.Services
         {
             return await _carRepository.SearchCarsAsync(search);
         }
-
 
         // ==============================
         // GET ALL
@@ -68,7 +67,6 @@ namespace backend.Services
             return carsWithInfo;
         }
 
-
         // ==============================
         // CREATE
         // ==============================
@@ -83,21 +81,19 @@ namespace backend.Services
 
             return createdCar;
         }
+
         public async Task<Car> CreateCarWithMakeAsync(string makeName, Car car)
         {
             if (string.IsNullOrWhiteSpace(makeName))
                 throw new ValidationException("Make name is required.");
 
-            // 1. Створюємо ОДНЕ з'єднання
             using var connection = _connectionFactory.CreateConnection();
             connection.Open();
 
-            // 2. Відкриваємо транзакцію
             using var transaction = connection.BeginTransaction();
 
             try
             {
-                // 3. Передаємо транзакцію (Dapper сам підхопить з'єднання з неї)
                 Make? make = await _makeRepository.GetMakeByNameAsync(makeName, transaction);
 
                 if (make == null)
@@ -110,19 +106,22 @@ namespace backend.Services
 
                 car.MakeId = make.Id;
 
-                // Передаємо ту саму транзакцію
+                ValidateCarForCreate(car);
+
+                var supplierExists = await _supplierRepository.ExistsByIdAsync(car.SupplierId);
+                if (!supplierExists)
+                    throw new ValidationException($"Supplier with id {car.SupplierId} not found.");
+
                 var createdCar = await _carRepository.CreateCarAsync(car, transaction);
 
                 if (createdCar == null) throw new ValidationException("Failed to create car.");
 
-                // 4. Якщо все ок — комітимо
                 transaction.Commit();
 
                 return createdCar;
             }
             catch
             {
-                // Якщо помилка — зміни автоматично скасуються при виході з using
                 throw;
             }
         }
@@ -142,7 +141,7 @@ namespace backend.Services
             if (existingCar == null)
                 throw new ValidationException($"Car with id {car.Id} not found.");
 
-            if(existingCar.Vin != car.Vin)
+            if (existingCar.Vin != car.Vin)
                 throw new ValidationException($"VIN cannot be changed in already existing car");
 
             var updatedCar = await _carRepository.UpdateCarAsync(car);
@@ -234,9 +233,6 @@ namespace backend.Services
             var supplier = await _supplierRepository.ExistsByIdAsync(car.SupplierId);
             if (supplier == false)
                 throw new ValidationException($"Supplier with id {car.SupplierId} not found.");
-
         }
-
-
     }
 }

--- a/backend/Services/CarService.cs
+++ b/backend/Services/CarService.cs
@@ -2,6 +2,7 @@
 using backend.Models;
 using backend.Repositories;
 using backend.Repositories.Interfaces;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Options;
 using System.Transactions;
 
@@ -14,14 +15,16 @@ namespace backend.Services
         private readonly IOrderRepository _orderRepository;
         private readonly IMakeRepository _makeRepository;
         private readonly ISupplierRepository _supplierRepository;
+        private readonly IDbConnectionFactory _connectionFactory;
 
-        public CarService(ICarRepository carRepository, ISaleRepository saleRepository,IOrderRepository orderRepository, IMakeRepository makeRepository, ISupplierRepository supplierRepository)
+        public CarService(ICarRepository carRepository, ISaleRepository saleRepository,IOrderRepository orderRepository, IMakeRepository makeRepository, ISupplierRepository supplierRepository, IDbConnectionFactory connectionFactory)
         {
             _carRepository = carRepository;
             _saleRepository = saleRepository;
             _orderRepository = orderRepository;
             _makeRepository = makeRepository;
             _supplierRepository = supplierRepository;
+            _connectionFactory = connectionFactory;
         }
 
         // ==============================
@@ -85,25 +88,43 @@ namespace backend.Services
             if (string.IsNullOrWhiteSpace(makeName))
                 throw new ValidationException("Make name is required.");
 
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            // 1. Створюємо ОДНЕ з'єднання
+            using var connection = _connectionFactory.CreateConnection();
+            connection.Open();
 
-            Make? make = await _makeRepository.GetMakeByNameAsync(makeName);
+            // 2. Відкриваємо транзакцію
+            using var transaction = connection.BeginTransaction();
 
-            if (make == null)
+            try
             {
-                make = new Make { Name = makeName };
-                make = await _makeRepository.CreateMakeAsync(make);
+                // 3. Передаємо транзакцію (Dapper сам підхопить з'єднання з неї)
+                Make? make = await _makeRepository.GetMakeByNameAsync(makeName, transaction);
 
                 if (make == null)
-                    throw new ValidationException("Failed to create make.");
+                {
+                    make = new Make { Name = makeName };
+                    make = await _makeRepository.CreateMakeAsync(make, transaction);
+
+                    if (make == null) throw new ValidationException("Failed to create make.");
+                }
+
+                car.MakeId = make.Id;
+
+                // Передаємо ту саму транзакцію
+                var createdCar = await _carRepository.CreateCarAsync(car, transaction);
+
+                if (createdCar == null) throw new ValidationException("Failed to create car.");
+
+                // 4. Якщо все ок — комітимо
+                transaction.Commit();
+
+                return createdCar;
             }
-
-            car.MakeId = make.Id;
-            var createdCar = await CreateCarAsync(car);
-
-            scope.Complete();
-
-            return createdCar;
+            catch
+            {
+                // Якщо помилка — зміни автоматично скасуються при виході з using
+                throw;
+            }
         }
 
         // ==============================

--- a/backend/Services/CarService.cs
+++ b/backend/Services/CarService.cs
@@ -3,6 +3,7 @@ using backend.Models;
 using backend.Repositories;
 using backend.Repositories.Interfaces;
 using Microsoft.Extensions.Options;
+using System.Transactions;
 
 namespace backend.Services
 {
@@ -84,39 +85,25 @@ namespace backend.Services
             if (string.IsNullOrWhiteSpace(makeName))
                 throw new ValidationException("Make name is required.");
 
-            Make? make = null;
-            bool isNewMake = false;
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
-            try
+            Make? make = await _makeRepository.GetMakeByNameAsync(makeName);
+
+            if (make == null)
             {
-                make = await _makeRepository.GetMakeByNameAsync(makeName);
+                make = new Make { Name = makeName };
+                make = await _makeRepository.CreateMakeAsync(make);
 
                 if (make == null)
-                {
-                    make = new Make { Name = makeName };
-                    make = await _makeRepository.CreateMakeAsync(make);
-                    if (make == null)
-                        throw new ValidationException("Failed to create make.");
-                    isNewMake = true;
-                }
-                car.MakeId = make.Id;
-                var createdCar = await CreateCarAsync(car);
-                return createdCar;
+                    throw new ValidationException("Failed to create make.");
             }
-            catch
-            {
-                if (isNewMake && make != null)
-                {
-                    try
-                    {
-                        await _makeRepository.DeleteMakeAsync(make.Id);
-                    }
-                    catch
-                    {
-                    }
-                    }
-                throw;
-            }
+
+            car.MakeId = make.Id;
+            var createdCar = await CreateCarAsync(car);
+
+            scope.Complete();
+
+            return createdCar;
         }
 
         // ==============================


### PR DESCRIPTION
Closes #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Car creation now runs as a single atomic operation to improve consistency and reliability when creating cars and their associated makes.
* **Bug Fixes**
  * Prevents partial creations—failed car creation no longer leaves orphaned or inconsistent make records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->